### PR TITLE
Add arm night mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ alarm_control_panel:
     payload_disarm: “DISARM”
     payload_arm_home: “ARM_HOME”
     payload_arm_away: “ARM_AWAY”
-#ARM_HOME = Arm_sleep @Line48 ip150.mqtt.py -- this will change in future releases
+    payload_arm_night: “ARM_NIGHT”
 ```
 #### Lovelace card for the alarm control panel
 ```
@@ -79,6 +79,7 @@ type: alarm-panel
 states:
   - arm_home
   - arm_away
+  - arm_night
 entity: alarm_control_panel.house_paradox
 name: Alarm
 ```

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ alarm_control_panel:
     payload_arm_home: “ARM_HOME”
     payload_arm_away: “ARM_AWAY”
     payload_arm_night: “ARM_NIGHT”
+#ARM_HOME = Arm_stay
+#ARM_AWAY = Arm
+#ARM_NIGHT = Arm_sleep
 ```
 #### Lovelace card for the alarm control panel
 ```

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Paradox IP150 MQTT Adapter",
-  "version": "0.6",
+  "version": "0.7",
   "slug": "paradox_ip150_mqtt",
   "description": "Expose an MQTT interface for the Paradox IP150 web interface",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],

--- a/ip150_mqtt.py
+++ b/ip150_mqtt.py
@@ -18,7 +18,7 @@ class IP150_MQTT():
 				'Disarmed'   : 'disarmed',
 				'Armed'      : 'armed_away',
 				'Triggered'  : 'triggered',
-				'Armed_sleep': 'armed_home',
+				'Armed_sleep': 'armed_night',
 				'Armed_stay' : 'armed_home',
 				'Entry_delay': 'pending',
 				'Exit_delay' : 'pending',
@@ -45,7 +45,8 @@ class IP150_MQTT():
 	_alarm_action_map = {
 		'DISARM': 'Disarm',
 		'ARM_AWAY': 'Arm',
-		'ARM_HOME': 'Arm_sleep'
+		'ARM_HOME': 'Arm_stay',
+		'ARM_NIGHT': 'Arm_sleep'
 		}
 
 	def __init__(self, opt_file):


### PR DESCRIPTION
**Description**
Addition of night arming mode as it is now supported in MQTT alarm control panel.
Gives user ability to Arm, Arm in Sleep (Night) & Arm in Stay (Home) modes

**Links/References**
1. [MQTT Alarm Control Panel - payload_arm_night](https://www.home-assistant.io/components/alarm_control_panel.mqtt/#payload_arm_night)
2. [alarm_control_panel.mqtt - PR](https://github.com/home-assistant/home-assistant.io/pull/8471)

**Testing:**
* Only done relatively basic tests, but so far all good

![image](https://user-images.githubusercontent.com/20188626/59052532-96032480-888f-11e9-87bf-e502cd74fb25.png)

![image](https://user-images.githubusercontent.com/20188626/59052582-ab784e80-888f-11e9-809d-0d3475d03ef2.png)

![image](https://user-images.githubusercontent.com/20188626/59052605-b8953d80-888f-11e9-862e-1930ad895074.png)

![image](https://user-images.githubusercontent.com/20188626/59052646-ca76e080-888f-11e9-8b81-9bba4c13d3f4.png)
